### PR TITLE
[DRAFT] Adds initial DAG for bib records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 logs*
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN git clone https://github.com/FOLIO-FSE/migration_repo_template migration
 RUN git clone https://github.com/FOLIO-FSE/MARC21-To-FOLIO --depth=2
 RUN chmod +x migration/create_folder_structure.sh
 RUN cd migration && rm -rf .git && ./create_folder_structure.sh
-RUN rm migration/instance/data/bib_example.mrc
+RUN rm migration/data/instance/bib_example.mrc
 RUN cd MARC21-To-FOLIO && pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM apache/airflow:2.2.2-python3.9
+
+USER root
+RUN apt-get -y update && apt-get -y install git
+USER airflow
+
+RUN git clone https://github.com/FOLIO-FSE/migration_repo_template migration
+RUN git clone https://github.com/FOLIO-FSE/MARC21-To-FOLIO --depth=2
+RUN chmod +x migration/create_folder_structure.sh
+RUN cd migration && rm -rf .git && ./create_folder_structure.sh
+RUN rm migration/instance/data/bib_example.mrc
+RUN cd MARC21-To-FOLIO && pip install -r requirements.txt

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -1,0 +1,102 @@
+"""Imports exported MARC records from Symphony into FOLIO"""
+
+from datetime import datetime, timedelta
+from textwrap import dedent
+
+from airflow import DAG
+
+from airflow.operators.python import PythonOperator
+from airflow.sensors.filesystem import FileSensor
+
+
+def read_marc(*args, **kwargs) -> list:
+    """Stub function for reading MARC21 records"""
+    return []
+
+
+def convert_to_folio(*args, **kwargs) -> list:
+    """Stub function for converting list of MARC21 to FOLIO json records"""
+    return []
+
+
+def load_records(*args, **kwargs) -> bool:
+    """Stub function for loading Inventory records into FOLIO"""
+    return True
+
+
+default_args = {
+    "owner": "folio",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    "symphony_marc_import",
+    default_args=default_args,
+    schedule_interval=timedelta(hours=1),
+    start_date=datetime(2022, 1, 3),
+    catchup=False,
+    tags=["bib_import"],
+) as dag:
+
+    dag.doc_md = dedent(
+        """
+    # Import Symphony MARC Records to FOLIO
+    Workflow for monitoring a file mount of exported MARC21 records from
+    Symphony ILS into [FOLIO](https://www.folio.org/) LSM.
+    """
+    )
+
+    monitor_file_mount = FileSensor(
+        task_id="marc21_monitor", filepath="/s/SUL/Dataload/Folio/"
+    )
+
+    monitor_file_mount.doc_md = dedent(
+        """\
+        ####  Monitor File Mount
+        Monitor's `/s/SUL/Dataload/Folio` for new MARC21 export files"""
+    )
+
+    read_marc_records = PythonOperator(
+        task_id="read_marc_records",
+        python_callable=read_marc,
+    )
+
+    read_marc_records.doc_md = dedent(
+        """\
+        #### Reads MARC21 file
+        Reads MARC21 binary file and returns a list of MARC records"""
+    )
+
+    convert_marc_to_folio = PythonOperator(
+        task_id="convert_marc_to_folio",
+        python_callable=convert_to_folio,
+        op_kwargs={"marc_records": "{{ ti.xcom_pull('read_marc_records') }}"},
+    )
+
+    convert_marc_to_folio.doc_md = dedent(
+        """\
+        #### Converts MARC21 Records to validated FOLIO Inventory Records
+        Task takes a list of MARC21 Records and converts them into the FOLIO
+        Inventory Records"""
+    )
+
+    load_folio_records = PythonOperator(
+        task_id="load_folio_records",
+        python_callable=load_records,
+        op_kwargs={
+            "folio_records": "{{ ti.xcom_pull('convert_marc_to_folio') }}"
+        },
+    )
+
+    load_folio_records.doc_md = dedent(
+        """\
+        #### Loads FOLIO Inventory Records
+        Loads FOLIO Inventory records into a running FOLIO instance"""
+    )
+
+    monitor_file_mount >> read_marc_records >> convert_marc_to_folio
+    convert_marc_to_folio >> load_folio_records

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -57,7 +57,7 @@ with DAG(
     monitor_file_mount = FileSensor(
         task_id="marc21_monitor",
         fs_conn_id="bib_path",
-        filepath="/opt/airflow/symphony/*.marc",
+        filepath="/opt/airflow/symphony/*.*rc",
         timeout=60 * 30
     )
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,8 +44,8 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.2.2}
-  # build: .
+  # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.2.2}
+  build: .
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
@@ -61,6 +61,7 @@ x-airflow-common:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
+    - ./symphony:/opt/airflow/symphony
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,7 @@ x-airflow-common:
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
     - ./symphony:/opt/airflow/symphony
-  user: "${AIRFLOW_UID:-50000}:0"
+  user: "${AIRFLOW_UID=$(id -u)}"
   depends_on:
     &airflow-common-depends-on
     redis:


### PR DESCRIPTION
Creates an initial DAG `bib_records.py` for monitoring a symphony mount at `/s/SUL/Dataload/Folio` for new MARC files. Current tasks are just stubs in the DAG that should call out to the modules in [MARC21-To-FOLIO](https://github.com/FOLIO-FSE/MARC21-To-FOLIO) or directly using the [FOLIO Client](https://github.com/FOLIO-FSE/FolioClient). 