### PR TITLE
Switch to use HoldingsCsvTransformer for Holdings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --chown=airflow:root migration migration/
 RUN chmod +x migration/create_folder_structure.sh
 RUN cd migration && rm -rf .git && ./create_folder_structure.sh
 
-# Once PR https://github.com/FOLIO-FSE/folio_migration_tools/pull/125 is merged
+# Once PR https://github.com/FOLIO-FSE/folio_migration_tools/pull/127 is merged
 # switch repo to use main branch of https://github.com/FOLIO-FSE/folio_migration_tools/
 RUN git clone -b fix-holdings-processor-init https://github.com/jermnelson/folio_migration_tools.git --depth=2
 

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -53,7 +53,7 @@ default_args = {
 with DAG(
     "symphony_marc_import",
     default_args=default_args,
-    schedule_interval=timedelta(hours=1),
+    schedule_interval=timedelta(minutes=5),
     start_date=datetime(2022, 1, 3),
     catchup=False,
     tags=["bib_import"],
@@ -71,7 +71,7 @@ with DAG(
         task_id="marc21_monitor",
         fs_conn_id="bib_path",
         filepath="/opt/airflow/symphony/*.*rc",
-        timeout=60 * 30,
+        timeout=270, # 4 1/2 minutes
     )
 
     monitor_file_mount.doc_md = dedent(

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -49,13 +49,13 @@ default_args = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,
-    "retry_delay": timedelta(minutes=15),
+    "retry_delay": timedelta(minutes=5),
 }
 
 with DAG(
     "symphony_marc_import",
     default_args=default_args,
-    schedule_interval=timedelta(minutes=5),
+    schedule_interval=timedelta(minutes=15),
     start_date=datetime(2022, 1, 3),
     catchup=False,
     tags=["bib_import"],

--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -33,10 +33,10 @@ logger = logging.getLogger(__name__)
 
 def move_marc_files(*args, **kwargs) -> list:
     """Function moves MARC files to instances and holdings"""
-    airflow = "/opt/airflow/"
+    airflow = "/opt/airflow"
     marc_files = []
-    for path in pathlib.Path(f"{airflow}symphony/").glob("*.*rc"):
-        target = pathlib.Path(f"{airflow}migration/data/instances/{path.name}")
+    for path in pathlib.Path(f"{airflow}/symphony/").glob("*.*rc"):
+        target = pathlib.Path(f"{airflow}/migration/data/instances/{path.name}")  # noqa
         shutil.move(path, target)
         logger.info(f"Moved MARC file to {target}")
         marc_files.append(path.name)

--- a/dags/folio_post.py
+++ b/dags/folio_post.py
@@ -40,15 +40,16 @@ def _get_files(files: list) -> list:
 
 def _generate_holdings_tsv(holdings_csv: csv.DictWriter, record: pymarc.Record):
     field001 = record.get_fields("001")[0]
-    field999 = record.get_fields("999")[0]
-    fields = {
-        "CALL_NUMBER": "".join([r for r in field999.get_subfields("a")]),
-        "CATKEY": field001.value(),
-        "LIBRARY": "".join([r for r in field999.get_subfields("m")]),
-        "LOCATION": "".join([r for r in field999.get_subfields("l")]),
-        "CALL_NUMBER_TYPE": "".join([r for r in field999.get_subfields("w")]),
-    }
-    holdings_csv.writerow(fields)
+    field999s = record.get_fields("999")
+    for field999 in field999s:
+        fields = {
+            "CALL_NUMBER": "".join([r for r in field999.get_subfields("a")]),
+            "CATKEY": field001.value(),
+            "LIBRARY": "".join([r for r in field999.get_subfields("m")]),
+            "LOCATION": "".join([r for r in field999.get_subfields("l")]),
+            "CALL_NUMBER_TYPE": "".join([r for r in field999.get_subfields("w")]),
+        }
+        holdings_csv.writerow(fields)
 
 
 def _move_001_to_035(record: pymarc.Record):

--- a/dags/folio_post.py
+++ b/dags/folio_post.py
@@ -234,7 +234,7 @@ def _post_to_okapi(**kwargs):
 def post_folio_instance_records(**kwargs):
     """Creates new records in FOLIO"""
 
-    batch_size = kwargs.get('MAX_ENTITIES', 9999)
+    batch_size = kwargs.get('MAX_ENTITIES', 1000)
     job_number = kwargs.get("job")
 
     with open(f"/tmp/instances-{job_number}.json") as fo:
@@ -242,7 +242,7 @@ def post_folio_instance_records(**kwargs):
 
     for i in range(0, len(instance_records), batch_size):
         instance_batch = instance_records[i:i+batch_size]
-        logger.info(f"Posting {i} to {i+batch_size}")
+        logger.info(f"Posting {len(instance_batch)} in batch {i}")
         _post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(
                 key="return_value", task_ids="post-to-folio.folio_login"
@@ -257,7 +257,7 @@ def post_folio_instance_records(**kwargs):
 def post_folio_holding_records(**kwargs):
     """Creates/overlays Holdings records in FOLIO"""
 
-    batch_size = kwargs.get('MAX_ENTITIES', 9999)
+    batch_size = kwargs.get('MAX_ENTITIES', 1000)
     job_number = kwargs.get("job")
 
     with open(f"/tmp/holdings-{job_number}.json") as fo:

--- a/dags/folio_post.py
+++ b/dags/folio_post.py
@@ -38,7 +38,7 @@ def _get_files(files: list) -> list:
     return output
 
 
-def _generate_holdings_tsv(holdings_csv: csv.DictWriter,
+def _generate_holdings_tsv(holdings_tsv: csv.DictWriter,
                            record: pymarc.Record):
     field001 = record.get_fields("001")[0]
     field999s = record.get_fields("999")
@@ -50,7 +50,7 @@ def _generate_holdings_tsv(holdings_csv: csv.DictWriter,
             "LOCATION": "".join([r for r in field.get_subfields("l")]),
             "CALL_NUMBER_TYPE": "".join([r for r in field.get_subfields("w")]),
         }
-        holdings_csv.writerow(fields)
+        holdings_tsv.writerow(fields)
 
 
 def _move_001_to_035(record: pymarc.Record):
@@ -66,8 +66,8 @@ def _move_001_to_035(record: pymarc.Record):
 
 
 def preprocess_marc(*args, **kwargs):
-    airflow = "/opt/airflow/"
-    holdings_tsv_file = open(f"{airflow}migration/data/items/sul-holdings.tsv", "w+")  # noqa
+    airflow = "/opt/airflow"
+    holdings_tsv_file = open(f"{airflow}/migration/data/items/sul-holdings.tsv", "w+")  # noqa
     holdings_tsv = csv.DictWriter(
         holdings_tsv_file,
         fieldnames=["CALL_NUMBER",
@@ -79,7 +79,7 @@ def preprocess_marc(*args, **kwargs):
     )
     holdings_tsv.writeheader()
 
-    for path in pathlib.Path(f"{airflow}symphony/").glob("*.*rc"):
+    for path in pathlib.Path(f"{airflow}/symphony/").glob("*.*rc"):
         marc_records = []
         marc_reader = pymarc.MARCReader(path.read_bytes())
         for record in marc_reader:


### PR DESCRIPTION
Generates a TSV file for Holdings migration based on the bib records' 999 fields.

FIXES #26  
FIXES #29 

TODO:
- [ ] Create a general ERR location if library ERR holding locations don't exist, need to update https://github.com/sul-dlss/folio_migration/blob/sul-999-bib-locations/mapping_files/locations.tsv#L215 