### PR TITLE
FOLIO Plugin for Reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,6 @@ RUN apt-get -y update && apt-get -y install git
 ENV PYTHONPATH "${PYTHONPATH}:/opt/airflow/folio_migration_tools"
 
 USER airflow
-COPY --chown=airflow:root migration migration/
-
-
-RUN chmod +x migration/create_folder_structure.sh
-RUN cd migration && rm -rf .git && ./create_folder_structure.sh
 
 # Once PR https://github.com/FOLIO-FSE/folio_migration_tools/pull/127 is merged
 # switch repo to use main branch of https://github.com/FOLIO-FSE/folio_migration_tools/

--- a/README.md
+++ b/README.md
@@ -30,5 +30,11 @@ We are using [poetry][POET] to better manage dependency updates. To install
 Be sure to add the path to your shell configuration file for `poetry --version` to work.
 Run `poetry install` to install the dependencies.
 
+## FOLIO Plugin
+All FOLIO related code should be in the `folio` plugin. When developing
+code in the plugin, you'll need to restart the `airflow-webserver` container
+by running `docker-compose restart airflow-webserver` to see changes in 
+the running Airflow environment. 
+
 ## Symphony Mount
 MARC data to be converted will be mounted on the sul-folio-airflow server under `/sirsi_dev` which is a mount of `/s/SUL/Dataload/Folio` on the Symphony server.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+# needed to import packages in the plugin
+
+import pathlib
+import sys
+
+root_directory = pathlib.Path(__file__).parent
+plugins_directory = root_directory / "plugins"
+
+sys.path.append(str(plugins_directory))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ x-airflow-common:
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
     - ./symphony:/opt/airflow/symphony
+    - ./migration:/opt/airflow/migration
   depends_on:
     &airflow-common-depends-on
     redis:

--- a/plugins/folio/main.py
+++ b/plugins/folio/main.py
@@ -1,30 +1,58 @@
+import logging
+import pathlib
+
+import markdown
+
 from airflow.plugins_manager import AirflowPlugin
 
+from flask import Blueprint
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
-migration_reports = {
-    "category": 'FOLIO',
-    "name": "Migration Reports",
-    "href": "#"
+MIGRATION_HOME = "/opt/airflow/migration"
+
+bp = Blueprint(
+    "folio_plugin",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/static/folio_plugin"
+)
+
+class FOLIO(AppBuilderBaseView):
+    default_view = "folio_view"
+
+    @expose("/")
+    def folio_view(self):
+        content = { }
+        for path in pathlib.Path(f"{MIGRATION_HOME}/reports").glob("*.md"):
+            reports.append(path.name)
+        return self.render_template("folio/index.html", content=reports)
+
+    @expose("/<report_name>")
+    def folio_report(self, report_name):
+        markdown_path = pathlib.Path(f"/opt/airflow/migration/reports/{report_name}")
+        rendered = markdown.markdown(markdown_path.read_text(), extensions=['md_in_html'])
+        return self.render_template("folio/report.html", content=rendered)
+
+    @expose("/<log_name>")
+    def folio_data_issues(self, log_name):
+        tsv_path = pathlib
+
+
+
+v_appbuilder_view = FOLIO()
+v_appbuilder_package = {
+    "name": "FOLIO Reports and Logs",
+    "category": "FOLIO",
+    "view": v_appbuilder_view
 }
-
-instance_logs = {
-    "category": 'FOLIO',
-    "name": "Instance Logs",
-    "href": "#"
-}
-
-holding_logs = {
-    "category": 'FOLIO',
-    "name": "Holding Logs",
-    "href": "#"
-}
-
 
 class FOLIOPlugin(AirflowPlugin):
     name = "FOLIOInformation"
     operators = []
-    flask_blueprints = []
+    flask_blueprints = [bp]
     hooks = []
     executors = []
     admin_views = []
-    appbuilder_menu_items = [migration_reports, instance_logs, holding_logs]
+    appbuilder_views = [v_appbuilder_package]
+    appbuilder_menu_items = []

--- a/plugins/folio/main.py
+++ b/plugins/folio/main.py
@@ -1,0 +1,30 @@
+from airflow.plugins_manager import AirflowPlugin
+
+
+migration_reports = {
+    "category": 'FOLIO',
+    "name": "Migration Reports",
+    "href": "#"
+}
+
+instance_logs = {
+    "category": 'FOLIO',
+    "name": "Instance Logs",
+    "href": "#"
+}
+
+holding_logs = {
+    "category": 'FOLIO',
+    "name": "Holding Logs",
+    "href": "#"
+}
+
+
+class FOLIOPlugin(AirflowPlugin):
+    name = "FOLIOInformation"
+    operators = []
+    flask_blueprints = []
+    hooks = []
+    executors = []
+    admin_views = []
+    appbuilder_menu_items = [migration_reports, instance_logs, holding_logs]

--- a/plugins/folio/main.py
+++ b/plugins/folio/main.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import pathlib
 
@@ -18,26 +19,61 @@ bp = Blueprint(
     static_url_path="/static/folio_plugin"
 )
 
+def _extract_dag_run_id(file_path: pathlib.Path) -> str:
+    """Extracts DAG ID run from file name, varies depending on file type"""
+    dag_run_id = None
+    path_parts = file_path.name.split("_")
+    if path_parts[0].startswith("transformation"):
+        dag_run_id = "_".join(path_parts[3:6])
+    if path_parts[0].startswith("failed_bib_records") and file_path.suffix == ".mrc":
+        dag_run_id = "_".join(path_parts[3:6])
+        # remove file extension
+        dag_run_id = dag_run_id.split(".")[0]
+    return dag_run_id
+
 class FOLIO(AppBuilderBaseView):
     default_view = "folio_view"
 
     @expose("/")
     def folio_view(self):
-        content = { }
-        for path in pathlib.Path(f"{MIGRATION_HOME}/reports").glob("*.md"):
-            reports.append(path.name)
-        return self.render_template("folio/index.html", content=reports)
+        content = {}
+        for path in pathlib.Path(f"{MIGRATION_HOME}/reports").iterdir():
+            dag_run_id = _extract_dag_run_id(path)
+            if not dag_run_id in content:
+                content[dag_run_id] = { "reports": [], "data_issues": [], "marc_errors": []}
+            if path.name.startswith("transformation"):
+                content[dag_run_id]["reports"].append(path.name)
+            if path.name.startswith("data_issues"):
+                content[dag_run_id]["data_issues"].append(path.name)
+        for path in pathlib.Path(f"{MIGRATION_HOME}/results").glob("failed_*.mrc"):
+            dag_run_id = _extract_dag_run_id(path)
+            if dag_run_id is None:
+                continue
+            content[dag_run_id]["marc_errors"].append( 
+                { "file": path.name, 
+                  "size": path.stat().st_size })
+        return self.render_template("folio/index.html", content=content)
 
-    @expose("/<report_name>")
+    @expose("/reports/<report_name>")
     def folio_report(self, report_name):
-        markdown_path = pathlib.Path(f"/opt/airflow/migration/reports/{report_name}")
-        rendered = markdown.markdown(markdown_path.read_text(), extensions=['md_in_html'])
+        markdown_path = pathlib.Path(f"{MIGRATION_HOME}/reports/{report_name}")
+        raw_text = markdown_path.read_text()
+        # Sets attribute to convert markdown in embedded HTML tags
+        final_mrkdown = raw_text.replace("<details>", """<details markdown="block">""")
+        rendered = markdown.markdown(final_mrkdown, extensions=['tables', 'md_in_html'])
         return self.render_template("folio/report.html", content=rendered)
 
-    @expose("/<log_name>")
+    @expose("/data_issues/<log_name>")
     def folio_data_issues(self, log_name):
-        tsv_path = pathlib
+        tsv_path = pathlib.Path(f"{MIGRATION_HOME}/results/{log_name}")
+        tsv_reader = csv.reader(tsv_path, delimiter="\t")
+        tsv_rows = [r for r in tsv_reader]
+        return self.render_template("folio/data-issues.html", content=tsv_rows)
 
+    @expose("/marc/<filename>")
+    def folio_marc_error(self, filename):
+        file_bytes = pathlib.Path(f"{MIGRATION_HOME}/results/{filename}").read_bytes()
+        return file_bytes
 
 
 v_appbuilder_view = FOLIO()

--- a/plugins/folio/templates/folio/data-issues.html
+++ b/plugins/folio/templates/folio/data-issues.html
@@ -1,0 +1,15 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<h2>Data Issues</h2>
+<table class="table table-striped">
+    <tr>
+        <th>Data</th>
+    </tr>
+    {% for row in content %}
+    <tr>
+        <td>{{ row.0 }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/plugins/folio/templates/folio/index.html
+++ b/plugins/folio/templates/folio/index.html
@@ -1,0 +1,18 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+<div>
+    <h2>FOLIO Reports</h2>
+    <ul>
+    {% for report in content.get('reports') %}
+    <li><a href="{{ url_for('FOLIO.folio_report', report_name=report) }}">{{ report }}</a></li>
+    {% endfor %}
+    </ul>
+    <h2>Data Issues Log</h2>
+    {% for issues_log in content.get('data_issues') %}
+    <ul>
+        <li><a href="{{ url_for('FOLIO.folio_data_issues, log_name=issues_log) }}">{{ issues_log }}</a></li>
+    </ul>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/plugins/folio/templates/folio/index.html
+++ b/plugins/folio/templates/folio/index.html
@@ -2,17 +2,42 @@
 
 {% block content %}
 <div>
-    <h2>FOLIO Reports</h2>
-    <ul>
-    {% for report in content.get('reports') %}
-    <li><a href="{{ url_for('FOLIO.folio_report', report_name=report) }}">{{ report }}</a></li>
+    <h2>FOLIO Migration by DAG Run</h2>
+    <table class="table table-striped">
+        <tr>
+            <th>DAG Run ID</th>
+            <th>Transformation Reports</th>
+            <th>Data Issues</th>
+            <th>Error MARC21 file</th>
+        </tr>
+    {% for dag_run_id, info in content.items() %}
+    <tr>
+        <td><a href="/graph?dag_id=symphony_marc_import&run_id={{ dag_run_id }}">{{ dag_run_id }}</a></td>
+        <td>
+            <ul>
+            {% for report in info.get('reports') %}
+            <li><a href="{{ url_for('FOLIO.folio_report', report_name=report) }}">{{ report }}</a></li>
+            {% endfor %}
+            </ul>
+        </td>
+        <td>
+            <ul>
+            {% for issues_log in info.get('data_issues') %}
+            <li><a href="{{ url_for('FOLIO.folio_data_issues', log_name=issues_log) }}">{{ issues_log }}</a></li>
+            {% endfor %}
+            </ul>
+        </td>
+        <td>
+            <ul>
+            {% for row in info.get('marc_errors') %}
+            <li><a href="{{ url_for('FOLIO.folio_marc_error', filename=row.file) }}">{{ row.file }}</a>
+             Size: {{ row.size }} kb
+            </li>
+            {% endfor %}
+            </ul>
+        </td>
+    </tr>
     {% endfor %}
-    </ul>
-    <h2>Data Issues Log</h2>
-    {% for issues_log in content.get('data_issues') %}
-    <ul>
-        <li><a href="{{ url_for('FOLIO.folio_data_issues, log_name=issues_log) }}">{{ issues_log }}</a></li>
-    </ul>
-    {% endfor %}
+    </table>
 </div>
 {% endblock %}

--- a/plugins/folio/templates/folio/report.html
+++ b/plugins/folio/templates/folio/report.html
@@ -1,0 +1,5 @@
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+{{ content|safe }}
+{% endblock %}

--- a/plugins/tests/test_main.py
+++ b/plugins/tests/test_main.py
@@ -1,0 +1,27 @@
+import pytest  # noqa
+
+from plugins.folio.main import _extract_dag_run_id
+
+
+def test_extract_dag_run_id_reports(tmp_path):
+    report = (
+        tmp_path
+        / "transformation_report_instances_manual__2022-02-14T23:27:04.675755+00:00_bibs.md"  # noqa
+    )
+    dag_id = _extract_dag_run_id(report)
+    assert dag_id == "manual__2022-02-14T23:27:04.675755+00:00"
+
+
+def test_extract_dag_run_id_mrc(tmp_path):
+    error_marc = (
+        tmp_path
+        / "failed_bib_records_manual__2022-02-14T23:36:51.056707+00:00.mrc"  # noqa
+    )
+    dag_id = _extract_dag_run_id(error_marc)
+    assert dag_id == "manual__2022-02-14T23:36:51.056707+00:00"
+
+
+def test_extract_dag_run_id_unknown(tmp_path):
+    unknown_file = tmp_path / "sample.txt"
+    dag_id = _extract_dag_run_id(unknown_file)
+    assert dag_id is None


### PR DESCRIPTION
FIXES #3 

Adds new FOLIO Plugin to display reports, logs, and errors from the transformers used in the`folio_migration_tools`.

In order to read these reports, logs, and errors from multiple Docker containers, mounting a `migration` volume instead of copying the migration folder into the image. This PR also starts unit testing with a test directory in the plugins directory. These tests can be run with `poetry run pytest` from the root directory.

## Screenshots
New **FOLIO** Menu item:
![Screen Shot 2022-02-14 at 10 10 20 AM](https://user-images.githubusercontent.com/71847/153912516-fd88876f-c7ea-4faa-9fc7-a15d5f4f465e.png)

Index page for all reports, logs, and error marc files:

![Screen Shot 2022-02-14 at 10 15 30 AM](https://user-images.githubusercontent.com/71847/153913315-d318541a-153a-4a20-b843-387bdaacd088.png)

Detailed view of transformation report:
![Screen Shot 2022-02-14 at 10 15 48 AM](https://user-images.githubusercontent.com/71847/153913377-a885df0a-7f56-44c9-9435-6072aab6c59e.png)


TODO:
- [x] Create tests for `_extract_dag_run_id` and investigate testing custom FOLIO views