### PR TITLE
Minor fixes and updates 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ USER airflow
 
 RUN git clone https://github.com/FOLIO-FSE/folio_migration_tools.git --depth=2
 
-RUN cd folio_migration_tools && pip install -r requirements.txt
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ by running `docker-compose restart airflow-webserver` to see changes in
 the running Airflow environment.
 
 ## Testing
-To run the test suite, use [pytest](https://docs.pytest.org/) with poetry, passing in the location of where you have local clone repository of the
+To run the test suite, use [pytest](https://docs.pytest.org/) passing in 
+the location of where you have local clone repository of the
 [folio_migration_tools/](https://github.com/foLIO-FSE/folio_migration_tools/)with the **PYTHONPATH** i.e.
 
-`PYTHONPATH='{path-to-folio_migration_tools}' poetry run pytest`
+`PYTHONPATH='{path-to-folio_migration_tools}' pytest`
 
 ## Symphony Mount
 MARC data to be converted will be mounted on the sul-folio-airflow server under `/sirsi_dev` which is a mount of `/s/SUL/Dataload/Folio` on the Symphony server.

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -52,7 +52,7 @@ def run_holdings_tranformer(*args, **kwargs):
         holdings_map_file_name="holdingsrecord_mapping.json",
         location_map_file_name="locations.tsv",
         default_call_number_type_name="Library of Congress classification",
-        default_holdings_type_id="03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+        fallback_holdings_type_id="03c9c400-b9e3-4a07-ac0e-05ab470233ed",
     )
 
     holdings_transformer = HoldingsCsvTransformer(


### PR DESCRIPTION
- Dockerfile copies and uses this repo's `requirements.txt` for installing dependencies
- README test section updated with poetry directions removed
- `HoldingsCsvTransformer.TaskConfiguration` changed parameter name with latest `folio_migration_tools` update
- Uses latest main commit for `folio_migration` submodule