### PR TITLE
Initial handling of Okapi record POST errors

### DIFF
--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -36,18 +36,24 @@ def move_marc_files_check_csv(*args, **kwargs) -> str:
     airflow = kwargs.get("airflow", "/opt/airflow")
     source_directory = kwargs["source"]
 
-    marc_path = next(pathlib.Path(f"{airflow}/{source_directory}/").glob("*.*rc"))  # noqa
+    marc_path = next(
+        pathlib.Path(f"{airflow}/{source_directory}/").glob("*.*rc")
+    )
     if not marc_path.exists():
         raise ValueError(f"MARC Path {marc_path} does not exist")
 
     # Checks for CSV file and sets XCOM marc_only if not present
-    csv_path = pathlib.Path(f"{airflow}/{source_directory}/{marc_path.stem}.csv")  # noqa
+    csv_path = pathlib.Path(
+        f"{airflow}/{source_directory}/{marc_path.stem}.csv"
+    )
     marc_only = True
     if csv_path.exists():
         marc_only = False
     task_instance.xcom_push(key="marc_only", value=marc_only)
 
-    marc_target = pathlib.Path(f"{airflow}/migration/data/instances/{marc_path.name}")  # noqa
+    marc_target = pathlib.Path(
+        f"{airflow}/migration/data/instances/{marc_path.name}"
+    )
     shutil.move(marc_path, marc_target)
 
     return marc_path.stem
@@ -68,7 +74,9 @@ def _move_001_to_035(record: pymarc.Record):
 def process_marc(*args, **kwargs):
     marc_stem = kwargs["marc_stem"]
 
-    marc_path = pathlib.Path(f"/opt/airflow/migration/data/instances/{marc_stem}.mrc")  # noqa
+    marc_path = pathlib.Path(
+        f"/opt/airflow/migration/data/instances/{marc_stem}.mrc"
+    )
     marc_reader = pymarc.MARCReader(marc_path.read_bytes())
 
     marc_records = []
@@ -149,7 +157,6 @@ def post_to_okapi(**kwargs) -> bool:
 def process_records(*args, **kwargs) -> list:
     """Function creates valid json from file of FOLIO objects"""
     prefix = kwargs.get("prefix")
-
     dag = kwargs["dag_run"]
 
     pattern = f"{prefix}*{dag.run_id}*.json"
@@ -183,9 +190,13 @@ def tranform_csv_to_tsv(*args, **kwargs):
     column_transforms = kwargs.get("column_transforms", [])
     source_directory = kwargs["source"]
 
-    csv_path = pathlib.Path(f"{airflow}/{source_directory}/{marc_stem}.csv")
+    csv_path = pathlib.Path(
+        f"{airflow}/{source_directory}/{marc_stem}.csv"
+    )
     if not csv_path.exists():
-        raise ValueError(f"CSV Path {csv_path} does not exist for {marc_stem}.mrc")  # noqa
+        raise ValueError(
+            f"CSV Path {csv_path} does not exist for {marc_stem}.mrc"
+        )
     df = pd.read_csv(csv_path, names=column_names)
 
     # Performs any transformations to values

--- a/plugins/folio/helpers.py
+++ b/plugins/folio/helpers.py
@@ -100,6 +100,8 @@ def post_to_okapi(**kwargs):
     endpoint = kwargs.get("endpoint")
     jwt = kwargs["token"]
 
+    dag_id = kwargs["dag_id"]
+
     records = kwargs["records"]
     payload_key = kwargs["payload_key"]
 
@@ -129,9 +131,7 @@ def post_to_okapi(**kwargs):
 
     if new_record_result.status_code > 399:
         logger.error(new_record_result.text)
-        raise ValueError(
-            f"FOLIO POST Failed with error code:{new_record_result.status_code}"  # noqa
-        )
+
 
 
 def process_records(*args, **kwargs) -> list:

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -43,8 +43,7 @@ def run_holdings_tranformer(*args, **kwargs):
 
     holdings_configuration = HoldingsCsvTransformer.TaskConfiguration(
         name="holdings-transformer",
-        migration_task_type="HoldingsMarcTransformer",
-        use_tenant_mapping_rules=False,
+        migration_task_type="HoldingsCsvTransformer",
         hrid_handling="default",
         files=[{"file_name": f"{holdings_stem}.tsv", "suppress": False}],
         create_source_records=False,

--- a/plugins/tests/test_helpers.py
+++ b/plugins/tests/test_helpers.py
@@ -1,9 +1,13 @@
-import pytest  # noqa
+import pytest
+import requests
 
+from airflow.models import Variable
+from pytest_mock import MockerFixture
 
 from plugins.folio.helpers import (
     archive_artifacts,
     move_marc_files_check_csv,
+    post_to_okapi,
     process_marc,
     tranform_csv_to_tsv,
 )
@@ -15,6 +19,97 @@ def test_archive_artifacts():
 
 def test_move_marc_files():
     assert move_marc_files_check_csv
+
+
+@pytest.fixture
+def mock_okapi_variable(monkeypatch):
+    def mock_get(key):
+        return "https://okapi-folio.dev.edu"
+
+    monkeypatch.setattr(Variable, "get", mock_get)
+
+
+@pytest.fixture
+def mock_dag_run(mocker: MockerFixture):
+    dag_run = mocker.stub(name="dag_run")
+    dag_run.run_id = "manual_2022-02-24"
+    return dag_run
+
+
+@pytest.fixture
+def mock_records():
+    return [
+        {"id": "de09e01a-6d75-4007-b700-c83a475999b1"},
+        {"id": "123326dd-9924-498f-9ca3-4fa00dda6c90"},
+    ]
+
+
+@pytest.fixture
+def mock_okapi_success(monkeypatch, mocker: MockerFixture):
+    def mock_post(*args, **kwargs):
+        post_response = mocker.stub(name="post_result")
+        post_response.status_code = 201
+
+        return post_response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+
+@pytest.mark.output_capturing
+def test_post_to_okapi(
+    mock_okapi_success, mock_okapi_variable, mock_dag_run, mock_records, caplog
+):
+
+    post_to_okapi(
+        token="2345asdf",
+        dag_run=mock_dag_run(),
+        records=mock_records,
+        endpoint="/instance-storage/batch/synchronous",
+        payload_key="instances",
+    )
+
+    assert "Result status code 201 for 2 records" in caplog.text
+
+
+@pytest.fixture
+def mock_okapi_failure(monkeypatch, mocker: MockerFixture):
+    def mock_post(*args, **kwargs):
+        post_response = mocker.stub(name="post_result")
+        post_response.status_code = 422
+        post_response.text = """{
+            "errors" : [ {
+                "message" : "value already exists in table holdings_record: hld100000000027"
+            } ]
+        }"""  # noqa
+        return post_response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+
+def test_post_to_okapi_failures(
+    mock_okapi_failure,
+    mock_okapi_variable,
+    mock_dag_run,
+    mock_records,
+    tmp_path
+):
+    migration_results = tmp_path / "migration" / "results"
+
+    migration_results.mkdir(parents=True)
+
+    post_to_okapi(
+        token="2345asdf",
+        dag_run=mock_dag_run,
+        records=mock_records,
+        endpoint="/instance-storage/batch/synchronous",
+        payload_key="instances",
+        airflow=tmp_path,
+    )
+
+    error_file = (
+        migration_results / "errors-instance-storage-422-manual_2022-02-24.json"  # noqa
+    )
+    assert error_file.exists()
 
 
 def test_process_marc():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 pydantic
 pymarc
 pytest
+pytest_mock


### PR DESCRIPTION
Fixes #33 

~~In draft because rebased off of branch `minor-fixes`. Once PR https://github.com/sul-dlss/folio-airflow/pull/44 is merged, will rebase off of main.~~

Instead of throwing a `ValueError` exception, now writes all of the record ids of failed POST requests to Okapi to the migration results directory following a file pattern of `errors-{storage-endpoint}-{http-error-code}-{dag_id}.json`. 

Created a follow-up ticket https://github.com/sul-dlss/folio-airflow/issues/45 for subsequent handling by a different DAG. 