### PR TITLE
Improved HRID Handling for Holdings and Items

### DIFF
--- a/dags/bib_records.py
+++ b/dags/bib_records.py
@@ -280,7 +280,7 @@ with DAG(
             post_instances = PythonOperator(
                 task_id=f"post_to_folio_instances_{i}",
                 python_callable=post_folio_instance_records,
-                op_kwargs={"job": i},
+                op_kwargs={"job": i, "MAX_ENTITIES": 25},
             )
 
             login >> post_instances >> finish_instances
@@ -304,7 +304,7 @@ with DAG(
             post_holdings = PythonOperator(
                 task_id=f"post_to_folio_holdings_{i}",
                 python_callable=post_folio_holding_records,
-                op_kwargs={"job": i},
+                op_kwargs={"job": i, "MAX_ENTITIES": 25},
             )
 
             start_holdings >> post_holdings >> finish_holdings
@@ -315,7 +315,7 @@ with DAG(
             post_items = PythonOperator(
                 task_id=f"post_to_folio_items_{i}",
                 python_callable=post_folio_items_records,
-                op_kwargs={"job": i},
+                op_kwargs={"job": i, "MAX_ENTITIES": 25},
             )
 
             finish_holdings >> post_items >> finish_items >> finished_all_posts

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -74,4 +74,3 @@ def run_holdings_tranformer(*args, **kwargs):
 
     # Manually increment HRID holdings and save
     holdings_transformer.mapper.store_hrid_settings()
-

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -10,6 +10,14 @@ from plugins.folio.helpers import post_to_okapi
 logger = logging.getLogger(__name__)
 
 
+def _add_hrid(holdings_transformer):
+    mapper = holdings_transformer.mapper
+    for record in holdings_transformer.holdings.values():
+        num_part = str(mapper.holdings_hrid_counter).zfill(11)
+        record['hrid'] = f"{mapper.holdings_hrid_prefix}{num_part}"
+        mapper.holdings_hrid_counter += 1
+
+
 def post_folio_holding_records(**kwargs):
     """Creates/overlays Holdings records in FOLIO"""
     dag = kwargs["dag_run"]
@@ -60,4 +68,10 @@ def run_holdings_tranformer(*args, **kwargs):
 
     holdings_transformer.do_work()
 
+    _add_hrid(holdings_transformer)
+
     holdings_transformer.wrap_up()
+
+    # Manually increment HRID holdings and save
+    holdings_transformer.mapper.store_hrid_settings()
+

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -20,7 +20,7 @@ def post_folio_items_records(**kwargs):
 
     for i in range(0, len(items_records), batch_size):
         items_batch = items_records[i:i + batch_size]
-        logger.info(f"Posting {i} to {i/batch_size} items records")
+        logger.info(f"Posting {len(items_batch)} in batch {i/batch_size}")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(
                 key="return_value", task_ids="post-to-folio.folio_login"
@@ -65,4 +65,8 @@ def run_items_transformer(*args, **kwargs) -> bool:
 
     items_transformer.wrap_up()
 
-    return True
+    # Manually set item HRID setting
+    items_transformer.mapper.hrid_settings['items']['startNumber'] += \
+        items_transformer.total_records + 1
+    items_transformer.mapper.store_hrid_settings() 
+    

--- a/plugins/folio/items.py
+++ b/plugins/folio/items.py
@@ -68,5 +68,4 @@ def run_items_transformer(*args, **kwargs) -> bool:
     # Manually set item HRID setting
     items_transformer.mapper.hrid_settings['items']['startNumber'] += \
         items_transformer.total_records + 1
-    items_transformer.mapper.store_hrid_settings() 
-    
+    items_transformer.mapper.store_hrid_settings()


### PR DESCRIPTION
CLOSES #39 

Sets HRID settings after Holdings and Items transformations, explicitly sets the HRID for Holdings, sets a batch of 25 records for Instances, Items, and Holdings posting.