### PR TITLE
Tests for holdings functions

### DIFF
--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -22,14 +22,16 @@ def post_folio_holding_records(**kwargs):
     """Creates/overlays Holdings records in FOLIO"""
     dag = kwargs["dag_run"]
 
+    tmp_location = kwargs.get("tmp_dir", "/tmp")
+
     batch_size = kwargs.get("MAX_ENTITIES", 1000)
     job_number = kwargs.get("job")
 
-    with open(f"/tmp/holdings-{dag.run_id}-{job_number}.json") as fo:
+    with open(f"{tmp_location}/holdings-{dag.run_id}-{job_number}.json") as fo:
         holding_records = json.load(fo)
 
     for i in range(0, len(holding_records), batch_size):
-        holdings_batch = holding_records[i:i + batch_size]
+        holdings_batch = holding_records[i : i + batch_size]
         logger.info(f"Posting {i} to {i+batch_size} holding records")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/plugins/folio/holdings.py
+++ b/plugins/folio/holdings.py
@@ -31,7 +31,7 @@ def post_folio_holding_records(**kwargs):
         holding_records = json.load(fo)
 
     for i in range(0, len(holding_records), batch_size):
-        holdings_batch = holding_records[i : i + batch_size]
+        holdings_batch = holding_records[i:i + batch_size]
         logger.info(f"Posting {i} to {i+batch_size} holding records")
         post_to_okapi(
             token=kwargs["task_instance"].xcom_pull(

--- a/plugins/tests/test_holdings.py
+++ b/plugins/tests/test_holdings.py
@@ -1,11 +1,60 @@
-from plugins.folio.holdings import (
-    post_folio_holding_records,
-    run_holdings_tranformer
-)
+import pytest
+import pydantic
+import requests
+
+from pytest_mock import MockerFixture
+from airflow.models import Variable
+
+from plugins.folio.holdings import post_folio_holding_records, run_holdings_tranformer
 
 
-def test_post_folio_holding_records():
-    assert post_folio_holding_records
+@pytest.fixture
+def mock_okapi_success(monkeypatch, mocker: MockerFixture):
+    def mock_post(*args, **kwargs):
+        post_response = mocker.stub(name="post_result")
+        post_response.status_code = 201
+
+        return post_response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+
+@pytest.fixture
+def mock_dag_run(mocker: MockerFixture):
+    dag_run = mocker.stub(name="dag_run")
+    dag_run.run_id = "manual_2022-03-05"
+    return dag_run
+
+
+@pytest.fixture
+def mock_okapi_variable(monkeypatch):
+    def mock_get(key):
+        return "https://okapi-folio.dev.edu"
+
+    monkeypatch.setattr(Variable, "get", mock_get)
+
+
+class MockTaskInstance(pydantic.BaseModel):
+    xcom_pull = lambda *args, **kwargs: "a0token"
+
+
+def test_post_folio_holding_records(
+    mock_okapi_success, mock_dag_run, mock_okapi_variable, tmp_path, caplog
+):
+
+    dag = mock_dag_run
+
+    holdings_json = tmp_path / f"holdings-{dag.run_id}-1.json"
+    holdings_json.write_text(
+        """[{ "id": "1233adf" }, 
+    { "id": "45ryry" }]"""
+    )
+
+    post_folio_holding_records(
+        tmp_dir=tmp_path, task_instance=MockTaskInstance(), dag_run=dag, job=1
+    )
+
+    assert "Result status code 201 for 2 records" in caplog.text
 
 
 def test_run_holdings_tranformer():


### PR DESCRIPTION
Fixes #49. 

Added comment about waiting until [folio_migration_tools](https://github.com/FOLIO-FSE/folio_migration_tools) can be installed with pip to test `run_holdings_tranformer` (otherwise would need to create complicated mocks for the transformers and dependent classes or clone a local copy of `folio_migration_tools`). 