### PR TITLE
Disabled Flower service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -251,21 +251,23 @@ services:
       - -c
       - airflow
 
-  flower:
-    <<: *airflow-common
-    command: celery flower
-    ports:
-      - 5555:5555
-    healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
-      interval: 10s
-      timeout: 10s
-      retries: 5
-    restart: always
-    depends_on:
-      <<: *airflow-common-depends-on
-      airflow-init:
-        condition: service_completed_successfully
+  # NOTE: jquery causing an security issue. Flower can be renabled when
+  # PR https://github.com/mher/flower/pull/1165 is merged.
+  # flower:
+  #   <<: *airflow-common
+  #   command: celery flower
+  #   ports:
+  #     - 5555:5555
+  #   healthcheck:
+  #     test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 5
+  #   restart: always
+  #   depends_on:
+  #     <<: *airflow-common-depends-on
+  #     airflow-init:
+  #       condition: service_completed_successfully
 
 volumes:
   postgres-db-volume:


### PR DESCRIPTION
 Once this PR [1165](https://github.com/mher/flower/pull/1165) is merged to fix security issue with an old version of jquery; we can renabled flower if we run into problems with Celery in our Airflow environment.